### PR TITLE
chore: update metabase from v1.44.4 to v1.46.4

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -7,7 +7,7 @@ metabase:
   image:
     repository: metabase/metabase-enterprise
     pullPolicy: IfNotPresent
-    tag: v1.44.4
+    tag: v1.46.4
   service:
     name: metabase
   database:


### PR DESCRIPTION
https://ccbc-metabase-dev.apps.silver.devops.gov.bc.ca/

I did a test deploy to dev and metabase enterprise v1.46.4 is working well