### PR TITLE
chore: reduce backup storage for non prod

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -77,7 +77,7 @@ crunchy-postgres:
         incremental: 0 0,4,12,16,20 * * *
       volume:
         accessModes: 'ReadWriteOnce'
-        storage: 2Gi
+        storage: 1Gi
         storageClassName: netapp-file-backup
     repoHost:
       requests:


### PR DESCRIPTION
Need to reduce backup storage as the hard limit of storage is being reached which is preventing deployments to test.